### PR TITLE
Fix Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Dirigible Labs is a community of open source projects that build technology base
 
 To add your existing GitHub repository as a Dirigible Labs project, open an issue against this repository and one of our administrators will guide you through the process.
 
-##Disclaimer
+## Disclaimer
+
 Dirigible Labs projects are not official Eclipse Foundation projects. Dirigible Labs projects are not hosted by the Eclipse Foundation and do not have to follow the Eclipse Foundation development and intellectual property policies.
 
 There are a number of things Dirigible Labs projects cannot do since they are not official Eclipse Foundation projects:
-* They cannot include the word Eclipse in their name.
-* They cannot use the org.eclipse namespace for their bundles names
+
+* They cannot include the word "Eclipse" in their name.
+* They cannot use the `org.eclipse` namespace for their bundles names
 * They cannot participate in the annual Eclipse release trains, unless they are included in an official Eclipse project.
 
-Full description about the User Guidelines can be found at https://wiki.eclipse.org/Dirigible/DirigibleLabs
+Full description about the User Guidelines can be found at <https://wiki.eclipse.org/Dirigible/DirigibleLabs>.


### PR DESCRIPTION
There IMHO was a space and newline missing in `README.md`. This PR fixes it.

## Before

![image](https://github.com/dirigiblelabs/dirigiblelabs/assets/1366654/7904376c-48af-43f8-ad3d-27764d28365f)

## After

![image](https://github.com/dirigiblelabs/dirigiblelabs/assets/1366654/5f8e1006-9b09-4d23-b925-e018dff7ffb0)
